### PR TITLE
Bug-Fix : Unwanted duplication of sections when running global search. ticket:239

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -160,11 +160,11 @@ class PluginGenericobjectObject extends CommonDBTM {
             if (!in_array($class, $CFG_GLPI['asset_types'])) {
                array_push($CFG_GLPI['asset_types'], $class);
             }
-            if (!in_array($class, $CFG_GLPI['globalsearch_types'])) {
-               array_push($CFG_GLPI['globalsearch_types'], $class);
-            }
             if (!in_array($class, $CFG_GLPI['state_types'])) {
                array_push($CFG_GLPI['state_types'], $class);
+               array_push($CFG_GLPI['globalsearch_types'], $class);
+            }
+            if (!in_array($class, $CFG_GLPI['globalsearch_types'])) {
                array_push($CFG_GLPI['globalsearch_types'], $class);
             }
          }


### PR DESCRIPTION
To avoid pushing twice the same thing into $CFG_GLPI['globalsearch_types'] we had to permute two if-blocs.

https://github.com/pluginsGLPI/genericobject/issues/239
